### PR TITLE
Update build task. Serve Fauxton at express-pouchdb, expect server there...

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -39,8 +39,8 @@
           "cachebuster": "?v1.0"
         },
         "app": {
-          "root": "/_utils/fauxton/",
-          "host": "../..",
+          "root": "/express-pouchdb/_utils/fauxton/",
+          "host": "/express-pouchdb",
           "version": "1.0"
         }
       },


### PR DESCRIPTION
... as well.

Hey, this is a partial fix for: https://github.com/pouchdb/express-pouchdb/issues/116

Example server: 

```
var port = 3001;

var express = require('express')
  , app     = express()
  , PouchDB = require('pouchdb')
  , logger  = require('morgan')
  ;

app.use(logger("tiny"));

app.get('/', function(req, res) {
  res.type('text/plain');
  res.send('i am a beautiful butterfly');
});

app.use('/express-pouchdb', require('express-pouchdb')(PouchDB));

console.log('listening on port ' + port);
app.listen(port);
```
