### PR TITLE
Serve Fauxton from relative path.

### DIFF
--- a/app/addons/auth/resources.js
+++ b/app/addons/auth/resources.js
@@ -35,7 +35,7 @@ function (app, FauxtonAPI, CouchdbSession) {
   var Admin = Backbone.Model.extend({
 
     url: function () {
-      return app.host + '/_config/admins/' + this.get("name");
+      return app.host + './_config/admins/' + this.get("name");
     },
 
     isNew: function () { return false; },
@@ -60,7 +60,7 @@ function (app, FauxtonAPI, CouchdbSession) {
   });
 
   Auth.Session = CouchdbSession.Session.extend({
-    url: app.host + '/_session',
+    url: app.host + './_session',
 
     initialize: function (options) {
       if (!options) { options = {}; }
@@ -174,7 +174,7 @@ function (app, FauxtonAPI, CouchdbSession) {
       return $.ajax({
         cache: false,
         type: "POST",
-        url: app.host + "/_session",
+        url: app.host + "./_session",
         dataType: "json",
         data: {name: username, password: password}
       }).then(function () {
@@ -187,7 +187,7 @@ function (app, FauxtonAPI, CouchdbSession) {
 
       return $.ajax({
         type: "DELETE",
-        url: app.host + "/_session",
+        url: app.host + "./_session",
         dataType: "json",
         username : "_",
         password : "_"

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -819,7 +819,7 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       this.moviePath = FauxtonAPI.getExtensions('zeroclipboard:movielist')[0];
 
       if (_.isUndefined(this.moviePath)) {
-       this.moviePath = app.host + app.root + "js/zeroclipboard/ZeroClipboard.swf";
+       this.moviePath = app.host + "js/zeroclipboard/ZeroClipboard.swf";
       }
 
       ZeroClipboard.config({ moviePath: this.moviePath });

--- a/app/addons/permissions/resources.js
+++ b/app/addons/permissions/resources.js
@@ -39,7 +39,7 @@ function (app, FauxtonAPI ) {
     },
 
     url: function () {
-      return window.location.origin +"/"+ this.database.safeID() + '/_security';
+      return "./"+ this.database.safeID() + '/_security';
     },
 
     addItem: function (value, type, section) {

--- a/app/addons/permissions/routes.js
+++ b/app/addons/permissions/routes.js
@@ -52,7 +52,7 @@ function (app, FauxtonAPI, Databases, Permissions) {
     crumbs: function () {
       return [
         {"name": this.database.id, "link": Databases.databaseUrl(this.database)},
-        {"name": "Permissions", "link": "/permissions"}
+        {"name": "Permissions", "link": "./permissions"}
       ];
     },
 

--- a/app/core/couchdbSession.js
+++ b/app/core/couchdbSession.js
@@ -14,7 +14,7 @@ define([
 function (FauxtonAPI) {
   var CouchdbSession = {
     Session: FauxtonAPI.Model.extend({
-      url: '/_session',
+      url: './_session',
 
       user: function () {
         var userCtx = this.get('userCtx');

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -39,22 +39,22 @@ function(utils, d3) {
   // Get the URL for documentation, wiki, wherever we store it.
   // update the URLs in documentation_urls.js
   Helpers.docs =  {
-    "docs": "/_utils/docs/intro/api.html#documents",
-    "all_dbs": "/_utils/docs/api/server/common.html?highlight=all_dbs#get--_all_dbs",
-    "replication_doc": "/_utils/docs/replication/replicator.html#basics",
-    "design_doc": "/_utils/docs/couchapp/ddocs.html#design-docs",
-    "design_doc_metadata" : "/_utils/docs/api/ddoc/common.html#api-ddoc-view-index-info",
-    "view_functions": "/_utils/docs/couchapp/ddocs.html#view-functions",
-    "map_functions": "/_utils/docs/couchapp/ddocs.html#map-functions",
-    "reduce_functions": "/_utils/docs/couchapp/ddocs.html#reduce-and-rereduce-functions",
-    "api_reference": "/_utils/docs/http-api.html",
-    "database_permission": "/_utils/docs/api/database/security.html#db-security",
-    "stats": "/_utils/docs/api/server/common.html?highlight=stats#get--_stats",
-    "_active_tasks": "/_utils/docs/api/server/common.html?highlight=stats#active-tasks",
-    "log": "/_utils/docs/api/server/common.html?highlight=stats#log",
-    "config": "/_utils/docs/config/index.html",
-    "views": "/_utils/docs/intro/overview.html#views",
-    "changes": "/_utils/docs/api/database/changes.html?highlight=changes#post--db-_changes"
+    "docs": "http://docs.couchdb.org/en/latest/intro/api.html#documents",
+    "all_dbs": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=all_dbs#get--_all_dbs",
+    "replication_doc": "http://docs.couchdb.org/en/latest/replication/replicator.html#basics",
+    "design_doc": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#design-docs",
+    "design_doc_metadata" : "http://docs.couchdb.org/en/latest/api/ddoc/common.html#api-ddoc-view-index-info",
+    "view_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#view-functions",
+    "map_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#map-functions",
+    "reduce_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#reduce-and-rereduce-functions",
+    "api_reference": "http://docs.couchdb.org/en/latest/http-api.html",
+    "database_permission": "http://docs.couchdb.org/en/latest/api/database/security.html#db-security",
+    "stats": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#get--_stats",
+    "_active_tasks": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#active-tasks",
+    "log": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#log",
+    "config": "http://docs.couchdb.org/en/latest/config/index.html",
+    "views": "http://docs.couchdb.org/en/latest/intro/overview.html#views",
+    "changes": "http://docs.couchdb.org/en/latest/api/database/changes.html?highlight=changes#post--db-_changes"
   };
 
   Helpers.getDocUrl = function(docKey){

--- a/settings.json
+++ b/settings.json
@@ -39,8 +39,8 @@
           "cachebuster": "?v1.0"
         },
         "app": {
-          "root": "/express-pouchdb/_utils/fauxton/",
-          "host": "/express-pouchdb",
+          "root": "./_utils/fauxton/",
+          "host": "./",
           "version": "1.0"
         }
       },

--- a/settings.json
+++ b/settings.json
@@ -39,8 +39,8 @@
           "cachebuster": "?v1.0"
         },
         "app": {
-          "root": "/_utils/fauxton/",
-          "host": "../..",
+          "root": "/express-pouchdb/_utils/fauxton/",
+          "host": "/express-pouchdb",
           "version": "1.0"
         }
       },


### PR DESCRIPTION
Hi, this PR takes @thesli's comments and suggestions and packages them into a PR.

You can test this PR like this:

1) Clone couchdb-fauxton
2) `grunt release` to build the changes.
3) put together a test server:

package.json

```
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "main": "test.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "express": "^4.9.8",
    "express-pouchdb": "^0.7.1",
    "morgan": "^1.4.0",
    "pouchdb": "^3.0.6"
  }
}
```

Test.js

```
var express = require('express')
  , app     = express()
  , PouchDB = require('pouchdb')
  , logger  = require('morgan')
  ;

app.use(logger("tiny"));
app.get('/', function(req, res, next) { 
  res.send('Welcome Traveler!  <a href="/express-pouchdb/_utils">Fauxton?</a>');
});
app.use('/custom', require('express-pouchdb')(PouchDB));

app.listen(3000);
```

To run the server with new Fauxton (assuming test and couchdb-fauxton are in same dir)

```
npm install
cd node_modules/express-pouchdb
mv fauxton fauxton.old
ln -s ../../../couchdb-fauxton/dist/release fauxton
node test.js
```

This addresses several issues identified and a couple extra.  From my testing, these issues remain, but none of them are show stoppers.  Compared to not working, 90% working is much better!
- Databases -> Any DB -> Compact & Clean -> Cleanup Views -> "Error: missing" -> POST /custom//newdatabase/_view_cleanup 404
- Databases -> Any DB -> All Design Docs -> Add Doc -> Hmmm... Adds regular doc.
- Create Design Doc through Gear -> New View -> Design Doc Metadata
- Url's have format like: GET /custom//_users -> double // isn't awesome.
- API URL -> wrong url http://localhost:3000/newdatabase2/_all_docs  should include custom path. http://localhost:3000/custom/newdatabase2/_all_docs
